### PR TITLE
Add exception handling to JSON.parse

### DIFF
--- a/lib/filestore.js
+++ b/lib/filestore.js
@@ -147,7 +147,7 @@ function loadFromFile(filePath, cb) {
     var data = fs.readFileSync(filePath, 'utf8');
 
     if (!data) {
-      throw new Error('Could not read from cookie file ' + filePath + '. Please ensure it exists');
+      throw new Error('Could not read from cookie file ' + filePath + '. Please ensure it exists.');
     }
 
     try {

--- a/lib/filestore.js
+++ b/lib/filestore.js
@@ -145,7 +145,17 @@ function saveToFile(filePath, data, cb) {
 
 function loadFromFile(filePath, cb) {
     var data = fs.readFileSync(filePath, 'utf8');
-    var dataJson = data ? JSON.parse(data) : null;
+
+    if (!data) {
+      throw new Error('Could not read from cookie file ' + filePath + '. Please ensure it exists');
+    }
+
+    try {
+      var dataJson = JSON.parse(data);
+    } catch (e) {
+      throw new Error('Could not parse cookie file ' + filePath + '. Please ensure it is not corrupted.');
+    }
+
     for(var domainName in dataJson) {
         for(var pathName in dataJson[domainName]) {
             for(var cookieName in dataJson[domainName][pathName]) {

--- a/lib/filestore.js
+++ b/lib/filestore.js
@@ -146,14 +146,14 @@ function saveToFile(filePath, data, cb) {
 function loadFromFile(filePath, cb) {
     var data = fs.readFileSync(filePath, 'utf8');
 
-    if (!data) {
-      throw new Error('Could not read from cookie file ' + filePath + '. Please ensure it exists.');
-    }
-
-    try {
-      var dataJson = JSON.parse(data);
-    } catch (e) {
-      throw new Error('Could not parse cookie file ' + filePath + '. Please ensure it is not corrupted.');
+    if (data) {
+      try {
+        var dataJson = JSON.parse(data);
+      } catch (e) {
+        throw new Error('Could not parse cookie file ' + filePath + '. Please ensure it is not corrupted.');
+      }
+    } else {
+      var dataJson = null;
     }
 
     for(var domainName in dataJson) {


### PR DESCRIPTION
In case of a corrupted cookie file (which I've encountered today, probably as a result of #3), the error thrown is not at all obvious. I've added error handling to the JSON.parse call so that it is obvious when something breaks because of this.
