### PR TITLE
Removes the trailing / from the path

### DIFF
--- a/lib/filestore.js
+++ b/lib/filestore.js
@@ -94,6 +94,10 @@ FileCookieStore.prototype.findCookies = function(domain, path, cb) {
 };
 
 FileCookieStore.prototype.putCookie = function(cookie, cb) {
+    if (cookie.path.length > 1  && cookie.path.lastIndexOf('/') === cookie.path.length-1) {
+       cookie.path = cookie.path.substr(0,cookie.path.length-1);
+    }
+
     if (!this.idx[cookie.domain]) {
         this.idx[cookie.domain] = {};
     }


### PR DESCRIPTION
To align to the  permutePath function in tough-cookie strips the trailing / off the path.
