### PR TITLE
Avoid parallel fs.writeFile() operations on same file

### DIFF
--- a/lib/filestore.js
+++ b/lib/filestore.js
@@ -14,7 +14,7 @@ function FileCookieStore(filePath) {
     loadFromFile(this.filePath, function(dataJson) {
         if(dataJson)
             self.idx = dataJson;
-    })
+    });
 }
 util.inherits(FileCookieStore, Store);
 exports.FileCookieStore = FileCookieStore;
@@ -135,12 +135,38 @@ FileCookieStore.prototype.removeCookies = function removeCookies(domain, path, c
     });
 };
 
-function saveToFile(filePath, data, cb) {
+// Avoid parallel writes to the same file
+var _writing_ = {};
+function writeFile(filePath, data, done) {
     var dataJson = JSON.stringify(data);
+    var wo = { done: done, next: [] };
+    _writing_[filePath] = wo;
     fs.writeFile(filePath, dataJson, function (err) {
+        // If we have new pending writes, execute them now
+        if ( wo.next.length ) {
+            writeFile(filePath, wo.data, wo.next);
+        }
+        else {
+            delete _writing_[filePath];
+        }
         if (err) throw err;
-        cb();
+        wo.done.forEach(function(cb) {
+            cb();
+        });
     });
+}
+
+function saveToFile(filePath, data, cb) {
+    var wo = _writing_[filePath];
+    // If not writing to this file, start writing right now
+    if ( !wo ) {
+        writeFile(filePath, data, [cb]);
+    }
+    // If writing in process, add to pending
+    else {
+        wo.data = data;
+        wo.next.push(cb);
+    }
 }
 
 function loadFromFile(filePath, cb) {


### PR DESCRIPTION
Without this update, I get up to 20 parallel `fs.writeFile()` operations.

With this update it would wait until current `fs.writeFile()` operation ends before executing the next one.
Also if there are more calls to `saveToFile()` while writing, only the last call would actually write to file, but all callbacks are invoked.