### PR TITLE
fixed fs.writeFile multiple times on the same file bug

### DIFF
--- a/lib/filestore.js
+++ b/lib/filestore.js
@@ -137,10 +137,12 @@ FileCookieStore.prototype.removeCookies = function removeCookies(domain, path, c
 
 function saveToFile(filePath, data, cb) {
     var dataJson = JSON.stringify(data);
-    fs.writeFile(filePath, dataJson, function (err) {
-        if (err) throw err;
+    try {
+        fs.writeFileSync(filePath, dataJson);
         cb();
-    });
+    } catch (e) {
+        throw e
+    }
 }
 
 function loadFromFile(filePath, cb) {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "tough-cookie-filestore",
+  "name": "tough-cookie-filestore-bugfixed",
   "version": "0.0.2",
   "description": "file store for tough-cookie",
   "main": "index.js",
-  "author": "mitsuru",
+  "author": "XueSeason",
   "license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/mitsuru/tough-cookie-filestore.git"
+		"url": "git@github.com:XueSeason/tough-cookie-filestore.git"
 	},
   "dependencies": {
     "tough-cookie": "~0.12.1"


### PR DESCRIPTION
When I use this module, I find a bug. This bug will always happened when multiple times update cookie.

From the node.js doc for fs.writeFile():

> Note that it is unsafe to use fs.writeFile() multiple times on the same file without waiting for the callback. For this scenario,  fs.createWriteStream() is strongly recommended.

I didn't use stream here, because it will change too much code. For respecting author's design, I think it is better to use writeFileSync if we ignore a little performance.